### PR TITLE
fix: type value

### DIFF
--- a/raw/io.pnut.core.language.md
+++ b/raw/io.pnut.core.language.md
@@ -13,7 +13,7 @@ This raw item identifies the original language of the post or message text. It c
 
 ~~~ js
 {
-    "type": "io.pnut.core.oembed",
+    "type": "io.pnut.core.language",
     "value": {
         "language": "ja"
     }


### PR DESCRIPTION
If you follow [original annotation of app.net](https://github.com/appdotnet/object-metadata/blob/e570eeefe3ad4414c0c9c9dfa37f756d6e6efcae/annotations/net.app.core.language.md) , correct value will be`io.pnut.core.language`.